### PR TITLE
[BE] keyPress event와 소켓 간 연동

### DIFF
--- a/server/src/service/minos/I.mino.ts
+++ b/server/src/service/minos/I.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class IMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'red';
     this.name = 'I';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class IMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][0] = STATUS.MINO;
-    this.blockArea[1][0] = STATUS.MINO;
-    this.blockArea[2][0] = STATUS.MINO;
-    this.blockArea[3][0] = STATUS.MINO;
+    this.blockArea[0][0] = STATUS.I_MINO;
+    this.blockArea[1][0] = STATUS.I_MINO;
+    this.blockArea[2][0] = STATUS.I_MINO;
+    this.blockArea[3][0] = STATUS.I_MINO;
   }
 }
 

--- a/server/src/service/minos/J.mino.ts
+++ b/server/src/service/minos/J.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class JMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'orange';
     this.name = 'J';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class JMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][1] = STATUS.MINO;
-    this.blockArea[1][1] = STATUS.MINO;
-    this.blockArea[2][1] = STATUS.MINO;
-    this.blockArea[2][0] = STATUS.MINO;
+    this.blockArea[0][1] = STATUS.J_MINO;
+    this.blockArea[1][1] = STATUS.J_MINO;
+    this.blockArea[2][1] = STATUS.J_MINO;
+    this.blockArea[2][0] = STATUS.J_MINO;
   }
 }
 

--- a/server/src/service/minos/L.mino.ts
+++ b/server/src/service/minos/L.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class LMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'yellow';
     this.name = 'L';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class LMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][0] = STATUS.MINO;
-    this.blockArea[1][0] = STATUS.MINO;
-    this.blockArea[2][0] = STATUS.MINO;
-    this.blockArea[2][1] = STATUS.MINO;
+    this.blockArea[0][0] = STATUS.L_MINO;
+    this.blockArea[1][0] = STATUS.L_MINO;
+    this.blockArea[2][0] = STATUS.L_MINO;
+    this.blockArea[2][1] = STATUS.L_MINO;
   }
 }
 

--- a/server/src/service/minos/O.mino.ts
+++ b/server/src/service/minos/O.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class OMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'green';
     this.name = 'O';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class OMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][1] = STATUS.MINO;
-    this.blockArea[1][1] = STATUS.MINO;
-    this.blockArea[0][0] = STATUS.MINO;
-    this.blockArea[1][0] = STATUS.MINO;
+    this.blockArea[0][1] = STATUS.O_MINO;
+    this.blockArea[1][1] = STATUS.O_MINO;
+    this.blockArea[0][0] = STATUS.O_MINO;
+    this.blockArea[1][0] = STATUS.O_MINO;
   }
 }
 

--- a/server/src/service/minos/S.mino.ts
+++ b/server/src/service/minos/S.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class SMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'blue';
     this.name = 'S';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class SMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][1] = STATUS.MINO;
-    this.blockArea[0][2] = STATUS.MINO;
-    this.blockArea[1][1] = STATUS.MINO;
-    this.blockArea[1][0] = STATUS.MINO;
+    this.blockArea[0][1] = STATUS.S_MINO;
+    this.blockArea[0][2] = STATUS.S_MINO;
+    this.blockArea[1][1] = STATUS.S_MINO;
+    this.blockArea[1][0] = STATUS.S_MINO;
   }
 }
 

--- a/server/src/service/minos/T.mino.ts
+++ b/server/src/service/minos/T.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class TMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'indigo';
     this.name = 'T';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class TMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][0] = STATUS.MINO;
-    this.blockArea[0][1] = STATUS.MINO;
-    this.blockArea[0][2] = STATUS.MINO;
-    this.blockArea[1][1] = STATUS.MINO;
+    this.blockArea[0][0] = STATUS.T_MINO;
+    this.blockArea[0][1] = STATUS.T_MINO;
+    this.blockArea[0][2] = STATUS.T_MINO;
+    this.blockArea[1][1] = STATUS.T_MINO;
   }
 }
 

--- a/server/src/service/minos/Z.mino.ts
+++ b/server/src/service/minos/Z.mino.ts
@@ -3,13 +3,12 @@ import Position from '@/types/position';
 import STATUS from '@/service/status';
 
 class ZMino extends Mino {
+  color: string;
   name: string;
 
-  constructor(
-    color: string = 'white',
-    initValue: Position = { xPos: 0, yPos: 0 }
-  ) {
-    super(color);
+  constructor(initValue: Position = { xPos: 0, yPos: 0 }) {
+    super();
+    this.color = 'purple';
     this.name = 'Z';
     this.pivotReferenceBlock.xPos = initValue.xPos;
     this.pivotReferenceBlock.yPos = initValue.yPos;
@@ -17,10 +16,10 @@ class ZMino extends Mino {
   }
 
   init() {
-    this.blockArea[0][0] = STATUS.MINO;
-    this.blockArea[0][1] = STATUS.MINO;
-    this.blockArea[1][1] = STATUS.MINO;
-    this.blockArea[1][2] = STATUS.MINO;
+    this.blockArea[0][0] = STATUS.Z_MINO;
+    this.blockArea[0][1] = STATUS.Z_MINO;
+    this.blockArea[1][1] = STATUS.Z_MINO;
+    this.blockArea[1][2] = STATUS.Z_MINO;
   }
 }
 

--- a/server/src/service/minos/block/index.ts
+++ b/server/src/service/minos/block/index.ts
@@ -1,20 +1,18 @@
-import Position from "@/types/position";
+import Position from '@/types/position';
 
 class Block {
-    color?: string;
-    xPos: number;
-    yPos: number;
+  xPos: number;
+  yPos: number;
 
-    constructor(color?: string, xPos?: number, yPos?: number) {
-        this.color = color;
-        this.xPos = xPos || 0;
-        this.yPos = yPos || 0;
-    }
+  constructor(xPos?: number, yPos?: number) {
+    this.xPos = xPos || 0;
+    this.yPos = yPos || 0;
+  }
 
-    setPosition({ xPos, yPos }: Position) {
-        this.xPos = xPos;
-        this.yPos = yPos;
-    }
+  setPosition({ xPos, yPos }: Position) {
+    this.xPos = xPos;
+    this.yPos = yPos;
+  }
 }
 
 export default Block;

--- a/server/src/service/minos/mino/index.ts
+++ b/server/src/service/minos/mino/index.ts
@@ -1,18 +1,14 @@
-import STATUS from '@/service/status';
 import Block from '@/service/minos/block';
 
 const TETRA = 4;
 
 class Mino {
-  [name: string]: any;
   protected blockArea: number[][];
   protected pivotReferenceBlock: Block;
 
-  constructor(color?: string) {
-    this.blockArea = new Array(TETRA)
-      .fill(0)
-      .map((el) => [STATUS.VOID, STATUS.VOID, STATUS.VOID, STATUS.VOID]);
-    this.pivotReferenceBlock = new Block(color);
+  constructor() {
+    this.blockArea = this.initBlockArea();
+    this.pivotReferenceBlock = new Block();
   }
 
   setpivotReference(block: Block) {
@@ -27,16 +23,31 @@ class Mino {
     return this.pivotReferenceBlock;
   }
 
+  private initBlockArea() {
+    return new Array(TETRA).fill(0).map((el) => [0, 0, 0, 0]);
+  }
+
   moveRight() {
-    this.pivotReferenceBlock.xPos++;
+    if (typeof this.pivotReferenceBlock.xPos === 'number') {
+      this.pivotReferenceBlock.xPos++;
+    }
   }
 
   moveLeft() {
-    this.pivotReferenceBlock.xPos--;
+    if (typeof this.pivotReferenceBlock.xPos === 'number') {
+      this.pivotReferenceBlock.xPos--;
+    }
   }
 
   moveDown() {
-    this.pivotReferenceBlock.yPos++;
+    if (typeof this.pivotReferenceBlock.yPos === 'number') {
+      this.pivotReferenceBlock.yPos++;
+    }
+  }
+  moveUp() {
+    if (typeof this.pivotReferenceBlock.xPos === 'number') {
+      this.pivotReferenceBlock.yPos--;
+    }
   }
 
   rotateLeft() {
@@ -47,7 +58,6 @@ class Mino {
       }
     }
     this.blockArea = newArea;
-    return this;
   }
 
   rotateRight() {
@@ -58,13 +68,6 @@ class Mino {
       }
     }
     this.blockArea = newArea;
-    return this;
-  }
-
-  print() {
-    for (let i = 0; i < TETRA; i++) {
-      console.log(this.blockArea[i]);
-    }
   }
 }
 

--- a/server/src/service/nickname/index.ts
+++ b/server/src/service/nickname/index.ts
@@ -1,12 +1,12 @@
 import { Service } from 'typedi';
-// import RedisClient from '@/databases/redis';
+import RedisClient from '@/databases/redis';
 import adjectives from '@/service/nickname/adjective';
 import nouns from '@/service/nickname/noun';
 import { removeDuplicateFromArray, createRandomNumber } from '@/utils';
 
 @Service()
 class NicknameService {
-  // @Inject('nicknameDB') nicknameDB!: RedisClient;
+  @Inject('nicknameDB') nicknameDB!: RedisClient;
   readonly adjs: string[];
   readonly names: string[];
 

--- a/server/src/service/nickname/index.ts
+++ b/server/src/service/nickname/index.ts
@@ -1,12 +1,12 @@
 import { Service } from 'typedi';
-import RedisClient from '@/databases/redis';
+// import RedisClient from '@/databases/redis';
 import adjectives from '@/service/nickname/adjective';
 import nouns from '@/service/nickname/noun';
 import { removeDuplicateFromArray, createRandomNumber } from '@/utils';
 
 @Service()
 class NicknameService {
-  @Inject('nicknameDB') nicknameDB!: RedisClient;
+  // @Inject('nicknameDB') nicknameDB!: RedisClient;
   readonly adjs: string[];
   readonly names: string[];
 

--- a/server/src/service/status/index.ts
+++ b/server/src/service/status/index.ts
@@ -1,7 +1,12 @@
 enum STATUS {
-    VOID = 0,
-    FULL = 1,
-    MINO = 2,
+  VOID = 0,
+  I_MINO = 1,
+  J_MINO = 2,
+  L_MINO = 3,
+  O_MINO = 4,
+  S_MINO = 5,
+  T_MINO = 6,
+  Z_MINO = 7,
 }
 
 export default STATUS;

--- a/server/src/sockets/eventManager/index.ts
+++ b/server/src/sockets/eventManager/index.ts
@@ -8,7 +8,7 @@ export const addKeyPressEvent = (
   userNumber: number,
   userGameMap: TetrisGame
 ) => {
-  console.log('previewInit : ', userGameMap.previewMinoInit());
+  // console.log('previewInit : ', userGameMap.previewMinoInit());
 
   const userName = `user:${userNumber}`;
   socket.on('pressUpKey', (data) => {
@@ -90,16 +90,30 @@ export const addKeyPressEvent = (
 
   socket.on('pressLeftRotateKey', (data) => {
     sendMessageToUser(serverSocket, userName, data);
+    if (userGameMap.rotateMino('COUNTER_CLOCK_WISE')) {
+      console.log('반시계 방향으로 회전합니다.');
+      return sendMessageToUser(
+        serverSocket,
+        userName,
+        '블럭을 회전시켰습니다.'
+      );
+    }
+    console.log('회전에 실패했습니다.');
+    return sendMessageToUser(serverSocket, userName, '회전에 실패했습니다.');
   });
 
   socket.on('pressRightRotateKey', (data) => {
     sendMessageToUser(serverSocket, userName, data);
-  });
-
-  socket.on('test', (data) => {
-    sendMessageToUser(serverSocket, userName, data);
-    userGameMap.getNextMino();
-    console.log('next Preview : ', userGameMap.previewMino().name);
+    if (userGameMap.rotateMino('CLOCK')) {
+      console.log('시계 방향으로 회전합니다.');
+      return sendMessageToUser(
+        serverSocket,
+        userName,
+        '블럭을 회전시켰습니다.'
+      );
+    }
+    console.log('회전에 실패했습니다.');
+    return sendMessageToUser(serverSocket, userName, '회전에 실패했습니다.');
   });
 };
 

--- a/server/src/test.html
+++ b/server/src/test.html
@@ -46,7 +46,7 @@
         socket.emit('pressEscapeKey', 'escape');
       }
       if (keyboardEvent.key === 'j') {
-        socket.emit('join', 'join');
+        socket.emit('joinPvP', 'join');
       }
       if (keyboardEvent.key === 'l') {
         socket.emit('quit', 'leave');
@@ -59,6 +59,12 @@
       }
       if (keyboardEvent.key === 'x') {
         socket.emit('pressRightRotateKey', 'x');
+      }
+      if (keyboardEvent.key === 't') {
+        socket.emit('test', 't');
+      }
+      if (keyboardEvent.key === 's') {
+        socket.emit('start', 't');
       }
     });
   </script>


### PR DESCRIPTION
## ✅ 작업 내용
- 회전을 가능하게 소켓을 연동하였다.
- 모양에 따라 색이 다르게 들어가도록 하였다.
- 이상이 이전 commit의 내용이며, 이제 현재 예상되는 keyPress socket event를 모두 정의했다.
- 리팩토링이 필요할 것.
    - 예상되는 구간은, 추후 프론트와 엮은 후 @/service/map의 this.print()를 없애는 것과 isMovable과 isRotatable 함수의 중복 제거이다.
- 또한 @/sockets의 gameManager와 roomManager의 기능을 추가할 것.

## 🔒 관련 이슈(닫을 이슈)
-  #2
    - 다 끝난 줄 알았으나, 회전 로직과, 각 블럭의 Status 값 변환으로 인해 이제서야 닫는다.